### PR TITLE
Fix time format in video player timestamps

### DIFF
--- a/src/VideoPlayer/VideoPlayer.jsx
+++ b/src/VideoPlayer/VideoPlayer.jsx
@@ -793,7 +793,7 @@ function VideoPlayer({
                 min={0}
               />
               <span className="time">
-                {currentTime[0]}:{currentTime[1]} / {duration[0]}:{duration[1]}
+                {currentTime[0]}:{String(currentTime[1]).padStart(2,"0")} / {duration[0]}:{String(duration[1]).padStart(2,"0")}
               </span>
             </>
           )}


### PR DESCRIPTION
Fixed the issue where timestamps were displayed as 0:0 / 1:0 instead of 0:00 / 1:00.
Updated the formatting logic to ensure timestamps always show two digits for seconds when necessary.