### PR TITLE
Feed Selection dropdown and menu auto hide when display mode is changed/opened

### DIFF
--- a/src/components/FeedPlayer/FeedPlayer.jsx
+++ b/src/components/FeedPlayer/FeedPlayer.jsx
@@ -1799,6 +1799,8 @@ function FeedPlayer({
                   onClick={() => {
                     setCurrentDisplayMode(mode.key);
                     setShowDisplayModesPopup(false);
+                    setShowControlsMenu(false);
+                    setIsDropdownActive(false);
                   }}
                   title={mode.label}
                 >
@@ -1998,7 +2000,11 @@ function FeedPlayer({
           {/* Display Modes Button */}
           <button
             className="control-button display-modes"
-            onClick={() => setShowDisplayModesPopup(!showDisplayModesPopup)}
+            onClick={() => {
+              setShowDisplayModesPopup(!showDisplayModesPopup)
+              setShowControlsMenu(false);
+              setIsDropdownActive(false);
+            }}
             title="Display Modes"
           >
             <i className="ri-layout-grid-line"></i>


### PR DESCRIPTION
When Display mode button is clicked or Display mode is changed, then the Feed selection dropdown and Menu option are auto hidden