### PR TITLE
Add DISCORD_BOT_TOKEN fallback: browser cache → feed/.env → docker/.env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,6 @@ VITE_API_BASE_URL2=https://discord-backend-492125307479.us-central1.run.app/api
 # See membersense/backend/.env for Discord configuration
 
 
-# To be used only if discord/.env DISCORD_BOT_TOKEN not found
-# Not yet implemented here. Still uses feed/membersense/backend/.env
-
+# DISCORD_BOT_TOKEN priority: browser cache (request body) → feed/.env → docker/.env
+# Set here as fallback if docker/.env is not present
 DISCORD_BOT_TOKEN=

--- a/membersense/backend/src/server.js
+++ b/membersense/backend/src/server.js
@@ -36,22 +36,42 @@ const handleRequest = async (req) => {
   }
 
   // Auto-login using backend token
+
   if (method === 'POST' && path === '/api/auth/auto-login') {
     logRequest(req);
     try {
-      const backendToken = process.env.DISCORD_BOT_TOKEN;
+      // 1. Check if token was passed from browser cache via request body
+      let body = {};
+      try { body = await req.json(); } catch (_) { }
+
+      // 2. Fall back to feed/.env or docker/.env via environment
+      //    Priority: browser cache → DISCORD_BOT_TOKEN (feed/.env) → DISCORD_BOT_TOKEN_DOCKER (docker/.env)
+      const backendToken =
+        body.token ||
+        process.env.DISCORD_BOT_TOKEN ||
+        process.env.DISCORD_BOT_TOKEN_DOCKER;
+
       if (!backendToken) {
-        throw new Error('No Discord bot token configured on backend');
+        throw new Error(
+          'No Discord bot token found. Checked: request body (browser cache), feed/.env, docker/.env'
+        );
       }
-      
+
+      const tokenSource =
+        body.token ? 'browser cache' :
+          process.env.DISCORD_BOT_TOKEN ? 'feed/.env' :
+            'docker/.env';
+
+      console.log(`Using DISCORD_BOT_TOKEN from: ${tokenSource}`);
+
       const { client, guildInfo } = await createBot(backendToken);
       const sessionId = nanoid();
       sessions.set(sessionId, { bot: client, token: backendToken });
       console.log(`Auto-login session created: ${sessionId}`);
-      return new Response(JSON.stringify({ 
-        sessionId, 
-        message: 'Auto-login successful',
-        ...guildInfo // This spreads serverName, memberCount, and iconURL into the response
+      return new Response(JSON.stringify({
+        sessionId,
+        message: `Auto-login successful (token source: ${tokenSource})`,
+        ...guildInfo
       }), {
         status: 200,
         headers: { ...corsHeaders, 'Content-Type': 'application/json' },
@@ -64,7 +84,7 @@ const handleRequest = async (req) => {
       });
     }
   }
-
+  
   // Manual login (for custom tokens)
   if (method === 'POST' && path === '/api/auth/login') {
     logRequest(req);


### PR DESCRIPTION
- Auto-login route now checks request body first (browser cache)
- Falls back to DISCORD_BOT_TOKEN in feed/.env
- Falls back to DISCORD_BOT_TOKEN_DOCKER in docker/.env
- Logs and returns which token source was used
- Updated .env.example to document priority order

Addresses #27